### PR TITLE
Fiksa forvirringer som kan oppstå på rapport

### DIFF
--- a/Kartverket.Web/Views/Admin/Index.cshtml
+++ b/Kartverket.Web/Views/Admin/Index.cshtml
@@ -57,14 +57,7 @@
                     <td>
                         @report.TotalObjects
                     </td>
-                    <td>@(report.Review switch
-                        {
-                            ReviewStatus.Resolved => "Godkjent",
-                            ReviewStatus.Closed => "Avslått",
-                            ReviewStatus.Draft => "Utkast",
-                            ReviewStatus.Submitted => "Uåpnet rapport",
-                            _ => report.Review.ToString()
-                        })</td> 
+                    <td>@report.Review.GetDisplayName()</td> 
                     <td>
                         <a class="nav-link, text-dark"
                         asp-controller="Admin"

--- a/Kartverket.Web/Views/Admin/ObjectReview.cshtml
+++ b/Kartverket.Web/Views/Admin/ObjectReview.cshtml
@@ -19,7 +19,7 @@
                         asp-route-id="@Model.Id">Tilbake</a>
                         @if(Model.SelectedObject != null)
                         {
-                            @if(Model.SelectedObject.Title == "")
+                            @if(string.IsNullOrWhiteSpace(Model.SelectedObject.Title))
                             {
                                 <p class="is-size-3"><em>Objekt uten tittel</em></p>
                             }
@@ -28,7 +28,7 @@
                             }
                             
                             <br />
-                            @if(Model.SelectedObject.Description == "")
+                            @if(string.IsNullOrWhiteSpace(Model.SelectedObject.Description))
                             {
                                 <p><em>Ingen beskrivelse på objekt ...</em></p>
                             }

--- a/Kartverket.Web/Views/Admin/ReportInDepth.cshtml
+++ b/Kartverket.Web/Views/Admin/ReportInDepth.cshtml
@@ -17,7 +17,14 @@
             <div class="box row-flex">
                 <h2><strong>Beskrivelse:</strong></h2>
                 <br />
-                <p>@Model.Description</p>
+				@if (string.IsNullOrWhiteSpace(Model.Description))
+				{
+					<p><em>Ingen beskrivelse på rapport ...</em></p>
+				}
+				else
+				{
+                    <p>@Model.Description</p>
+				}
                 <br />
                 <p><strong>Rapportert:</strong> @Model.CreatedAt.ToString("yyyy-MM-dd HH:mm")</p>
             </div>
@@ -36,7 +43,7 @@
                         @foreach (var obj in Model.Objects)
                         {
                             <tr>
-                                <td>@if(obj.Title == "")
+                                <td>@if(string.IsNullOrWhiteSpace(obj.Title))
                                     {
                                         <p><em>Objekt uten tittel</em></p>
                                     }
@@ -69,7 +76,7 @@
                 
                 @if(Model.SelectedObject is { } selObj)
                     {
-                        @if(selObj.Title == "")
+                        @if(string.IsNullOrWhiteSpace(selObj.Title))
                         {
                             <h3 class="title is-4"><em>Objekt uten tittel</em></h3>
                         }
@@ -78,7 +85,7 @@
                         }
                        
                         <br />
-                        @if(selObj.Description == "")
+                        @if(string.IsNullOrWhiteSpace(selObj.Description))
                         {
                             <p><em>Ingen beskrivelse på objekt ...</em></p>
                         }


### PR DESCRIPTION
Gjorde det lettere for kartverket å se på liste på rapporter når objekt ikke har tittel eller description. Fiksa også tror alle status slik at de bruker GetDisplayName, ser mye finere ut, bare se om alt fungerer før merger